### PR TITLE
fix panel title rendering twice and add submitToRestEndpoint custom f…

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -244,7 +244,7 @@ function decoratePanelContainer(panelDefinition, panelContainer) {
 
   const isPanelWrapper = (container) => container.classList?.contains('panel-wrapper');
 
-  const shouldAddLabel = (container, panel) => panel.label && !container.querySelector(`legend[for=${container.dataset.id}]`);
+  const shouldAddLabel = (container, panel) => panel.label && !container.querySelector('legend');
 
   if (isPanelWrapper(panelContainer)) {
     if (shouldAddLabel(panelContainer, panelDefinition)) {

--- a/blocks/form/functions.js
+++ b/blocks/form/functions.js
@@ -61,10 +61,33 @@ function customSubmitSuccessHandler(globals) {
   }
 }
 
+const REST_ENDPOINT = 'https://simple-mock-api.adobe-aem-hackathon.workers.dev/api/data';
+
+/**
+ * Submits form data to a REST endpoint and writes the returned id into the hidden 'id' field.
+ * @param {scope} globals - globals object with form instance and invoke method.
+ * @returns {Promise<void>}
+ */
+async function submitToRestEndpoint(globals) {
+  const data = globals.functions.exportData();
+  const response = await fetch(REST_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (response.ok) {
+    const result = await response.json();
+    if (result?.id !== undefined) {
+      globals.functions.importData({ ...data, id: result.id });
+    }
+  }
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export {
   getFullName,
   days,
   submitFormArrayToString,
   customSubmitSuccessHandler,
+  submitToRestEndpoint,
 };


### PR DESCRIPTION
…unction

- Fix decoratePanelContainer duplicate legend by checking for any existing legend element
- Add submitToRestEndpoint that POSTs form data to REST endpoint and writes returned id into hidden id field

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--securbank-aem-ue.hlx.live/
- After: https://chatbot--securbank-aem-ue.hlx.live/
