### PR TITLE
refactor submitToRestEndpoint to use Promise chain instead of async/a…

### DIFF
--- a/blocks/form/functions.js
+++ b/blocks/form/functions.js
@@ -68,19 +68,20 @@ const REST_ENDPOINT = 'https://simple-mock-api.adobe-aem-hackathon.workers.dev/a
  * @param {scope} globals - globals object with form instance and invoke method.
  * @returns {Promise<void>}
  */
-async function submitToRestEndpoint(globals) {
+function submitToRestEndpoint(globals) {
   const data = globals.functions.exportData();
-  const response = await fetch(REST_ENDPOINT, {
+  return fetch(REST_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
+  }).then((response) => {
+    if (!response.ok) return null;
+    return response.json().then((result) => {
+      if (result?.id !== undefined) {
+        globals.functions.importData({ ...data, id: result.id });
+      }
+    });
   });
-  if (response.ok) {
-    const result = await response.json();
-    if (result?.id !== undefined) {
-      globals.functions.importData({ ...data, id: result.id });
-    }
-  }
 }
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
…wait

Removes async keyword so function appears in rule editor list while still returning a Promise to ensure the rule engine waits for the fetch to complete.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--securbank-aem-ue.hlx.live/
- After: https://chatbot--securbank-aem-ue.hlx.live/
